### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ const model = createFallback({
 
 ```javascript
 import { createFallback } from 'ai-fallback'
-import { createOpenAI } from '@ai-sdk/openai'
-import { createAnthropic } from '@ai-sdk/anthropic'
+import { openai } from '@ai-sdk/openai'
+import { anthropic } from '@ai-sdk/anthropic'
 
 const model = createFallback({
     models: [
-        createAnthropic('claude-3-haiku-20240307'),
-        createOpenAI('gpt-3.5-turbo'),
+        anthropic('claude-3-haiku-20240307'),
+        openai('gpt-3.5-turbo'),
     ],
 })
 ```


### PR DESCRIPTION
nice work - this is awesome! 

The `createOpenAI` function takes in an optional options object rather than the name of the model. 

If you preferred to have an example with that uses the factory function rather than the regular provider instance you could do it like: 


```javascript
import { createFallback } from 'ai-fallback'
import { createOpenAI } from '@ai-sdk/openai'
import { createAnthropic } from '@ai-sdk/anthropic'

const openai = createOpenAI()
const anthropic = createAnthropic()

const model = createFallback({
    models: [
        anthropic('claude-3-haiku-20240307'),
        openai('gpt-3.5-turbo'),
    ],
})
```