### PR TITLE
Do not save last used model globally

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,26 +81,15 @@ export class FallbackModel implements LanguageModelV1 {
     currentModelIndex: number = 0
     private lastModelReset: number = Date.now()
     private readonly modelResetInterval: number
-    aiModelId: string | undefined;
     retryAfterOutput: boolean
     constructor(settings: Settings) {
         this.settings = settings
         this.modelResetInterval = settings.modelResetInterval ?? 3 * 60 * 1000 // Default 3 minutes in ms
         this.retryAfterOutput = settings.retryAfterOutput ?? false
-        // Use aiModelId if defined to find initial model
-        if (this.aiModelId) {
-            const modelIndex = settings.models.findIndex(
-                (p) => p.modelId === this.aiModelId,
-            )
-            if (modelIndex !== -1) {
-                this.currentModelIndex = modelIndex
-            }
-        }
 
         if (!this.settings.models[this.currentModelIndex]) {
             throw new Error('No models available in settings')
         }
-        this.aiModelId = this.settings.models[this.currentModelIndex].modelId
     }
 
     get defaultObjectGenerationMode(): 'json' | 'tool' | undefined {
@@ -119,7 +108,6 @@ export class FallbackModel implements LanguageModelV1 {
             this.currentModelIndex !== 0
         ) {
             this.currentModelIndex = 0
-            this.aiModelId = this.settings.models[0].modelId
             this.lastModelReset = now
         }
     }
@@ -127,7 +115,6 @@ export class FallbackModel implements LanguageModelV1 {
     private switchToNextModel() {
         this.currentModelIndex =
             (this.currentModelIndex + 1) % this.settings.models.length
-        this.aiModelId = this.settings.models[this.currentModelIndex].modelId
     }
 
     private async retry<T>(fn: () => PromiseLike<T>): Promise<T> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,6 @@ export function createFallback(settings: Settings): FallbackModel {
     return new FallbackModel(settings)
 }
 
-declare global {
-    var __aiModelId: string | undefined
-}
-
 const retryableStatusCodes = [
     401, // wrong API key
     403, // permission error, like cannot access model or from a non accessible region
@@ -85,15 +81,16 @@ export class FallbackModel implements LanguageModelV1 {
     currentModelIndex: number = 0
     private lastModelReset: number = Date.now()
     private readonly modelResetInterval: number
+    aiModelId: string | undefined;
     retryAfterOutput: boolean
     constructor(settings: Settings) {
         this.settings = settings
         this.modelResetInterval = settings.modelResetInterval ?? 3 * 60 * 1000 // Default 3 minutes in ms
         this.retryAfterOutput = settings.retryAfterOutput ?? false
-        // Use globalThis.modelId if defined to find initial model
-        if (globalThis.__aiModelId) {
+        // Use aiModelId if defined to find initial model
+        if (this.aiModelId) {
             const modelIndex = settings.models.findIndex(
-                (p) => p.modelId === globalThis.__aiModelId,
+                (p) => p.modelId === this.aiModelId,
             )
             if (modelIndex !== -1) {
                 this.currentModelIndex = modelIndex
@@ -103,8 +100,7 @@ export class FallbackModel implements LanguageModelV1 {
         if (!this.settings.models[this.currentModelIndex]) {
             throw new Error('No models available in settings')
         }
-        globalThis.__aiModelId =
-            this.settings.models[this.currentModelIndex].modelId
+        this.aiModelId = this.settings.models[this.currentModelIndex].modelId
     }
 
     get defaultObjectGenerationMode(): 'json' | 'tool' | undefined {
@@ -123,7 +119,7 @@ export class FallbackModel implements LanguageModelV1 {
             this.currentModelIndex !== 0
         ) {
             this.currentModelIndex = 0
-            globalThis.__aiModelId = this.settings.models[0].modelId
+            this.aiModelId = this.settings.models[0].modelId
             this.lastModelReset = now
         }
     }
@@ -131,8 +127,7 @@ export class FallbackModel implements LanguageModelV1 {
     private switchToNextModel() {
         this.currentModelIndex =
             (this.currentModelIndex + 1) % this.settings.models.length
-        globalThis.__aiModelId =
-            this.settings.models[this.currentModelIndex].modelId
+        this.aiModelId = this.settings.models[this.currentModelIndex].modelId
     }
 
     private async retry<T>(fn: () => PromiseLike<T>): Promise<T> {


### PR DESCRIPTION
Remove the functionality to keep track of the last used model globally to make sure a new instance is always using the primary model.
 
Saving the current ai model id globally leads to some unexpected behaviour e.g. whenever a new instance of the `FallbackModel` class is created I would expect that the primary model is used again, but instead some fallback model is used immediately. That behaviour might be wanted in some cases, but with the current implementation we would never go back to using the primary model because `lastModelReset` is set to the date of the instance creation again and therefore the condition `now - this.lastModelReset >= this.modelResetInterval` is never met if e.g. the `createFallback` is called on every AI request.

Imho we should leave the decision to the user if the primary model should be tried again on every request or the fallback solution is instantiated globally.