### PR TITLE
Add per-model provider options

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,33 @@ const model = createFallback({
 })
 ```
 
+#### Model-specific provider options
+
+Wrap a model in an object when a fallback needs different provider options:
+
+```javascript
+const model = createFallback({
+    models: [
+        {
+            model: google('gemini-3-pro-preview'),
+            providerOptions: {
+                google: {
+                    thinkingConfig: { thinkingBudget: 32768 },
+                },
+            },
+        },
+        {
+            model: google('gemini-2.5-flash-preview-09-2025'),
+            providerOptions: {
+                google: {
+                    thinkingConfig: { thinkingBudget: 24576 },
+                },
+            },
+        },
+    ],
+})
+```
+
 
 ---
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import { createAnthropic } from '@ai-sdk/anthropic'
 import { generateText, streamText, streamObject, tool } from 'ai'
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test'
 import {
+    LanguageModelV3GenerateResult,
     LanguageModelV3StreamPart,
 } from '@ai-sdk/provider'
 import { MockLanguageModelV3 } from './mock-model.js'
@@ -56,6 +57,97 @@ test('switches model on error', async () => {
     expect(model.modelId).toBe('claude-3-haiku-20240307')
     expect(result.text).toBeTruthy()
     model.currentModelIndex = 0
+})
+
+test('uses model-specific providerOptions when switching fallback models', async () => {
+    const overloadedError = Object.assign(new Error('Overloaded'), {
+        statusCode: 429,
+    })
+    const generateResult: LanguageModelV3GenerateResult = {
+        content: [{ type: 'text', text: 'ok' }],
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+            inputTokens: {
+                total: 1,
+                noCache: 1,
+                cacheRead: undefined,
+                cacheWrite: undefined,
+            },
+            outputTokens: {
+                total: 1,
+                text: 1,
+                reasoning: undefined,
+            },
+        },
+        warnings: [],
+    }
+
+    const primary = new MockLanguageModelV3({
+        provider: 'google',
+        modelId: 'gemini-3-pro-preview',
+        doGenerate: async () => {
+            throw overloadedError
+        },
+    })
+    const fallback = new MockLanguageModelV3({
+        provider: 'google',
+        modelId: 'gemini-2.5-flash-preview-09-2025',
+        doGenerate: generateResult,
+    })
+
+    const model = createFallback({
+        models: [
+            {
+                model: primary,
+                providerOptions: {
+                    google: {
+                        thinkingConfig: { thinkingBudget: 32768 },
+                    },
+                },
+            },
+            {
+                model: fallback,
+                providerOptions: {
+                    google: {
+                        thinkingConfig: { thinkingBudget: 24576 },
+                    },
+                },
+            },
+        ],
+    })
+
+    const result = await model.doGenerate({
+        prompt: [],
+        providerOptions: {
+            google: {
+                cachedContent: 'shared-cache-key',
+            },
+            openai: {
+                reasoningEffort: 'low',
+            },
+        },
+    })
+
+    expect(result).toBe(generateResult)
+    expect(model.currentModelIndex).toBe(1)
+    expect(primary.doGenerateCalls[0].providerOptions).toEqual({
+        google: {
+            cachedContent: 'shared-cache-key',
+            thinkingConfig: { thinkingBudget: 32768 },
+        },
+        openai: {
+            reasoningEffort: 'low',
+        },
+    })
+    expect(fallback.doGenerateCalls[0].providerOptions).toEqual({
+        google: {
+            cachedContent: 'shared-cache-key',
+            thinkingConfig: { thinkingBudget: 24576 },
+        },
+        openai: {
+            reasoningEffort: 'low',
+        },
+    })
 })
 
 test('groq switches model on error, switches to third model', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,16 @@ import {
 } from '@ai-sdk/provider'
 
 interface Settings {
-    models: Array<LanguageModelV3>
+    models: Array<LanguageModelV3 | FallbackModelSettings>
     retryAfterOutput?: boolean
     modelResetInterval?: number
     shouldRetryThisError?: (error: Error) => boolean
     onError?: (error: Error, modelId: string) => void | Promise<void>
+}
+
+export type FallbackModelSettings = {
+    model: LanguageModelV3
+    providerOptions?: LanguageModelV3CallOptions['providerOptions']
 }
 
 export function createFallback(settings: Settings): FallbackModel {
@@ -74,17 +79,47 @@ export function defaultShouldRetryThisError(error: any): boolean {
     return false
 }
 
+function getModel(model: LanguageModelV3 | FallbackModelSettings): LanguageModelV3 {
+    return 'model' in model ? model.model : model
+}
+
+function getModelProviderOptions(
+    model: LanguageModelV3 | FallbackModelSettings,
+): LanguageModelV3CallOptions['providerOptions'] | undefined {
+    return 'model' in model ? model.providerOptions : undefined
+}
+
+function mergeProviderOptions(
+    options?: LanguageModelV3CallOptions['providerOptions'],
+    modelOptions?: LanguageModelV3CallOptions['providerOptions'],
+): LanguageModelV3CallOptions['providerOptions'] | undefined {
+    if (!modelOptions) {
+        return options
+    }
+
+    const merged = { ...(options ?? {}) }
+
+    for (const [provider, providerOptions] of Object.entries(modelOptions)) {
+        merged[provider] = {
+            ...(merged[provider] ?? {}),
+            ...providerOptions,
+        }
+    }
+
+    return merged
+}
+
 export class FallbackModel implements LanguageModelV3 {
     readonly specificationVersion = 'v3' as const
 
     get supportedUrls():
         | Record<string, RegExp[]>
         | PromiseLike<Record<string, RegExp[]>> {
-        return this.settings.models[this.currentModelIndex].supportedUrls
+        return this.currentModel.supportedUrls
     }
 
     get modelId(): string {
-        return this.settings.models[this.currentModelIndex].modelId
+        return this.currentModel.modelId
     }
     readonly settings: Settings
 
@@ -103,7 +138,17 @@ export class FallbackModel implements LanguageModelV3 {
     }
 
     get provider(): string {
-        return this.settings.models[this.currentModelIndex].provider
+        return this.currentModel.provider
+    }
+
+    private get currentModel(): LanguageModelV3 {
+        return getModel(this.settings.models[this.currentModelIndex])
+    }
+
+    private get currentModelProviderOptions():
+        | LanguageModelV3CallOptions['providerOptions']
+        | undefined {
+        return getModelProviderOptions(this.settings.models[this.currentModelIndex])
     }
 
     private checkAndResetModel() {
@@ -152,10 +197,28 @@ export class FallbackModel implements LanguageModelV3 {
         } while (true)
     }
 
+    private optionsForCurrentModel(
+        options: LanguageModelV3CallOptions,
+    ): LanguageModelV3CallOptions {
+        const providerOptions = mergeProviderOptions(
+            options.providerOptions,
+            this.currentModelProviderOptions,
+        )
+
+        if (providerOptions === options.providerOptions) {
+            return options
+        }
+
+        return {
+            ...options,
+            providerOptions,
+        }
+    }
+
     doGenerate(options: LanguageModelV3CallOptions): PromiseLike<LanguageModelV3GenerateResult> {
         this.checkAndResetModel()
         return this.retry(() =>
-            this.settings.models[this.currentModelIndex].doGenerate(options),
+            this.currentModel.doGenerate(this.optionsForCurrentModel(options)),
         )
     }
 
@@ -166,8 +229,8 @@ export class FallbackModel implements LanguageModelV3 {
             this.settings.shouldRetryThisError || defaultShouldRetryThisError
         return this.retry(async () => {
             const result =
-                await self.settings.models[this.currentModelIndex].doStream(
-                    options,
+                await self.currentModel.doStream(
+                    self.optionsForCurrentModel(options),
                 )
 
             let hasStreamedAny = false


### PR DESCRIPTION
Closes #14.

## Summary
- allow fallback entries to wrap a model with model-specific `providerOptions`
- merge call-level provider options with the selected fallback model's provider options
- document the object entry form for models that need different provider-specific settings

## Validation
- `pnpm exec vitest run src/index.test.ts -t "model-specific providerOptions"`
- `pnpm build`
